### PR TITLE
n26: update twitter handle and domain

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -88,11 +88,11 @@ targets:
    Netcologne:
      hosts:
        - www.netcologne.de
-   Number26:
+   N26:
      hosts:
        - my.number26.de
-       - number26.de
-     twitter: '@number26'
+       - n26.com
+     twitter: '@n26'
    Wikipedia:
      hosts:
        - www.wikipedia.org


### PR DESCRIPTION
Number26 changed their twitter handle and main domain again.