### PR TITLE
Fixed logo colors and removed pprint() call

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,7 +4,7 @@ import asyncio
 import datetime
 import logging
 import os
-from pprint import pprint
+from pprint import pformat
 
 import aiodns
 import jsonschema
@@ -180,7 +180,7 @@ async def main():
 
 
     results = sorted(results.items(), key=lambda x: x[0])
-    pprint(results)
+    logging.debug(pformat(results))
     jinja_env = Environment(loader=FileSystemLoader('templates/'))
     template = jinja_env.get_template('index.jinja2')
     with open(os.path.join(args.dest, 'index.html'), 'w') as fh:

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -5,9 +5,17 @@
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">
     <style type="text/css">
-    <!--
-    .entry td { height: 60px; vertical-align: middle !important; };
-    -->
+    .entry td {
+        height: 60px;
+        vertical-align: middle !important;
+    }
+    #twitter-logo {
+        color: #00aced;
+    }
+    #github-logo {
+        color: #333;
+    }
+
     </style>
 </head>
 <body>
@@ -76,10 +84,10 @@
         </p>
         <p class="text-right">
             <a href="https://github.com/andir/ipv6.watch" title="GitHub" target="_blank">
-                <i class="fa fa-github fa-3x"></i>
+                <i class="fa fa-github fa-3x" id="github-logo"></i>
             </a>
             <a href="https://twitter.com/ipv6watch" title="Twitter" target="_blank">
-                <i class="fa fa-twitter fa-3x"></i>
+                <i class="fa fa-twitter fa-3x" id="twitter-logo"></i>
             </a>
         </p>
     </div>


### PR DESCRIPTION
Added the correct colors to the GitHub and Twitter logo in the footer of the page.

Also replaced the one remaing `pprint()` in `generate.py` with a proper `logging.debug()` call so it can be filtered by specifying a loglevel > DEBUG.


Best regards,
Felix