### PR TITLE
Added missing twitter handles + renamed Level 3 to CenturyLink

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -71,6 +71,12 @@ targets:
     hosts:
       - bing.com
       - www.bing.com
+    twitter: "@bing"
+  CenturyLink (formerly Level3):
+    href: https://www.centurylink.com
+    hosts:
+      - www.centurylink.com
+    twitter: "@CenturyLink @CenturyLinkHelp"
   CodePen:
     href: https://codepen.io
     hosts:
@@ -211,6 +217,7 @@ targets:
     hosts:
       - google.com
     icon: images/google.png
+    twitter: "@Google"
   Gravatar:
     href: https://www.gravatar.com
     hosts:
@@ -268,10 +275,7 @@ targets:
     hosts:
       - jetbrains.com
     icon: images/jetbrains.svg
-  Level3:
-    href: http://www.level3.com
-    hosts:
-      - www.level3.com
+    twitter: "@jetbrains"
   LinkedIn:
     href: https://www.linkedin.com
     hosts:
@@ -322,6 +326,7 @@ targets:
     href: https://www.netcologne.de
     hosts:
       - www.netcologne.de
+    twitter: "@NetCologne_GmbH"
   Netflix:
     href: https://www.netflix.com/
     hosts:
@@ -442,6 +447,7 @@ targets:
     hosts:
       - tidal.com
       - listen.tidal.com
+    twitter: "@TIDAL"
   Travis-CI:
     href: https://travis-ci.org
     hosts:
@@ -503,6 +509,7 @@ targets:
     hosts:
       - www.wikipedia.org
     icon: images/wikipedia.png
+    twitter: "@Wikipedia"
   Wordpress:
     href: https://wordpress.org
     hosts:


### PR DESCRIPTION
Added missing twitter handles for:

- Bing
- Google
- Jetbrains
- NetCologne
- TIDAL
- Wikipedia

I also renamed Level3 to CenturyLink.