### PR TITLE
Removed gitlab.com from hosts becuse their official website is about.…

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -214,8 +214,9 @@ targets:
   GitLab:
     href: https://about.gitlab.com
     hosts:
-      - gitlab.com
       - about.gitlab.com
+      - packages.gitlab.com
+      - docs.gitlab.com
     icon: images/gitlab.svg
     twitter: "@gitlab"
   Google:


### PR DESCRIPTION
Removed gitlab.com from hosts becuse their official website is about.gitlab.com. gitlab.com only redirects to their main domain.
Added packages.gitlab.com and docs.gitlab.com instead