### PR TITLE
add digitalocean

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -139,6 +139,13 @@ targets:
       - digg.com
     icon: "fa:digg"
     twitter: "@digg"
+  DigitalOcean:
+    href: https://digitalocean.com
+    hosts:
+      - digitalocean.com
+      - cloud.digitalocean.com
+    icon: "fa:digital-ocean"
+    twitter: "@digitalocean"
   Discord:
     href: https://discordapp.com/
     hosts:


### PR DESCRIPTION
Please add digitalocean. There seems to be some confusion if it is;

DigitalOcean (in <title> tag on the main page)
Digital Ocean (common sense) or
Digital-Ocean (font awesome)