### PR TITLE
Updating Spotify

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -440,6 +440,8 @@ targets:
     href: https://www.spotify.com
     hosts:
       - www.spotify.com
+      - open.scdn.co
+      - www.scdn.co
     icon: "fa:spotify"
     twitter: "@spotify"
   "Stack Exchange":


### PR DESCRIPTION
When on an IPv6 only network, the Spotify CDN servers are not reachable, resulting in both their homepage and the webplayer being broken.