### PR TITLE
Use newer NixOS channel for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,12 @@ on:
   pull_request:
   push:
 jobs:
-  test-nixos-2105:
+  test-nixos-2205:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: cachix/install-nix-action@v13
-      - run: NIX_PATH=channel:nixos-21.05 nix-shell --run "mkdir tmp && python generate.py -l DEBUG -c conf.yaml tmp"
+      - run: NIX_PATH=channel:nixos-22.05 nix-shell --run "mkdir tmp && python generate.py -l DEBUG -c conf.yaml tmp"
   test-nixos-unstable:
     runs-on: ubuntu-latest
     steps:
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: cachix/install-nix-action@v13
-      - run: NIX_PATH=channel:nixos-21.05 nix-shell --packages yq-go --run "diff conf.yaml <(yq eval 'sortKeys(..)' conf.yaml)"
+      - run: NIX_PATH=channel:nixos-22.05 nix-shell --packages yq-go --run "diff conf.yaml <(yq eval 'sortKeys(..)' conf.yaml)"

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "nameservers": {


### PR DESCRIPTION
NixOS 22.05 does have a newer version of jsonschema that has issues with
the `anyOf` node that we are using the schema.json. Since the `anyOf`
node seems to be part of some draft that isn't fully supported there
isn't an upstream fix just yet.

The upstream `jsonschema` bug is being tracked here: https://github.com/python-jsonschema/jsonschema/issues/847